### PR TITLE
Display "development" banner and discourage web crawlers from indexing the website

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Inject robots.txt file into assembled website file tree
         run: |
           cp content/robots.txt _build/html/robots.txt
+      - name: Append banner script to assembled index.html files
+        run: |
+          cat content/banner.js >> _build/html/legacy/nmdc-documentation/index.html
+          cat content/banner.js >> _build/html/nmdc/index.html
+          cat content/banner.js >> _build/html/nmdc-runtime-documentation/index.html
+          cat content/banner.js >> _build/html/workflows/mag-workflow-documentation/index.html
+          cat content/banner.js >> _build/html/workflows/mg-annotation-workflow-documentation/index.html
+          cat content/banner.js >> _build/html/index.html
       - name: Save the result for publishing to GitHub Pages  # Docs: https://github.com/actions/upload-pages-artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -62,6 +62,9 @@ jobs:
           cp -R content/assets _build/html/assets
           cp content/index.html _build/html/index.html
           ls -R _build/html
+      - name: Inject robots.txt file into assembled website file tree
+        run: |
+          cp content/robots.txt _build/html/robots.txt
       - name: Save the result for publishing to GitHub Pages  # Docs: https://github.com/actions/upload-pages-artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/content/banner.js
+++ b/content/banner.js
@@ -1,0 +1,17 @@
+(function () {
+    /**
+     * Create a banner and mount it to the DOM as the first element inside the `body`.
+     *
+     * @param innerHTML {string} The HTML content you want the banner to contain.
+     * @param backgroundColor {string} The CSS color of the banner's background.
+     */
+    function displayBanner(innerHTML = "", backgroundColor = "red") {
+        const divEl = document.createElement("div");
+        divEl.style.backgroundColor = backgroundColor;
+        divEl.style.textAlign = "center";
+        divEl.innerHTML = innerHTML;
+        document.body.insertBefore(divEl, document.body.firstChild);
+    }
+
+    displayBanner('<strong>This website is in early development.</strong> You can access our production documentation <a href="https://microbiomedata.org/documentation/" style="color: black;">here</a>.');
+})();

--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,0 +1,5 @@
+# This `robots.txt` file is designed to tell web crawlers that we do not want them to crawl any pages on this website.
+# Reference: https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt
+# TODO: Loosen or remove this rule once we are ready to launch the website.
+User-agent: *
+Disallow: /


### PR DESCRIPTION
In this branch, I made two changes related to ticket #49:
1. I added a banner that appears at the top of the web page and says the website is in early development. The banner includes a link to the documentation page of the NMDC website.
2. I configured the website so that it discourages web crawlers (such as Google's Googlebot) from indexing the website.