### PR TITLE
Implement Sphinx-themed Error 404 page using Sphinx extension

### DIFF
--- a/content/home/requirements.txt
+++ b/content/home/requirements.txt
@@ -2,6 +2,10 @@ myst-parser
 sphinx_markdown_tables
 sphinx_rtd_theme
 
-# Sphinx plugin that handles redirects.
+# Sphinx extension that handles redirects.
 # Reference: https://pypi.org/project/sphinx-reredirects/
 sphinx-reredirects
+
+# Sphinx extension that creates a `404.html` page in which static assets are properly referenced.
+# Reference: https://sphinx-notfound-page.readthedocs.io
+sphinx-notfound-page==1.0.4

--- a/content/home/src/conf.py
+++ b/content/home/src/conf.py
@@ -32,9 +32,10 @@ release = '0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-   'myst_parser',
-   'sphinx_markdown_tables',
-   'sphinx_reredirects',
+    'myst_parser',
+    'sphinx_markdown_tables',
+    'sphinx_reredirects',
+    'notfound.extension',
 ]
 
 # source_suffix = '.rst'
@@ -95,6 +96,16 @@ redirects = {
     "workflows.html": "/workflows/",
     "reference/metadata/xylene": "https://w3id.org/nmdc/xylene",  # the latter redirects to: https://microbiomedata.github.io/nmdc-schema/xylene/
     "reference/metadata/*": "https://w3id.org/nmdc/nmdc",
+}
+
+# -- Sphinx Not Found Page extension --------------------
+#
+# Reference: https://sphinx-notfound-page.readthedocs.io/en/latest/configuration.html
+#
+notfound_urls_prefix = None
+notfound_context = {
+    "title": "Page Not Found",
+    "body": "<h1>Page Not Found</h1>\n\nWe failed to find a page at that address.",
 }
 
 # -- Sphinx Read The Docs Theme -------------------------

--- a/content/legacy_home/requirements.txt
+++ b/content/legacy_home/requirements.txt
@@ -2,6 +2,6 @@ myst-parser
 sphinx_markdown_tables
 sphinx_rtd_theme
 
-# Sphinx plugin that handles redirects.
+# Sphinx extension that handles redirects.
 # Reference: https://pypi.org/project/sphinx-reredirects/
 sphinx-reredirects


### PR DESCRIPTION
In this branch, I introduced a custom Error 404 page to the home site.

The default GitHub Pages-generated page looks like this:

![image](https://github.com/user-attachments/assets/7e84f2cd-34f3-49e4-aa90-e6b7150630d7)

The custom page looks like this (in my development environment):

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/9a1d7126-5963-4c86-80ba-cbccaa902bce" />
