### PR TITLE
Standardize copyright message throughout website

### DIFF
--- a/.github/workflows/fetch-and-compile-runtime-docs.yml
+++ b/.github/workflows/fetch-and-compile-runtime-docs.yml
@@ -51,6 +51,7 @@ jobs:
         # - https://www.mkdocs.org/user-guide/cli/
         # - https://www.mkdocs.org/user-guide/configuration/#configuration-inheritance
         # - https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#favicon
+        # - https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/?h=copyright#copyright-notice
         #
         # TODO: Make the `site_url` configurable (e.g. via an environment variable).
         #
@@ -58,6 +59,7 @@ jobs:
         run: |
           echo '{
             "INHERIT": "mkdocs.yml",
+            "copyright": "&copy; Copyright 2024, National Microbiome Data Collaborative",
             "site_dir": "${{ github.workspace }}/_dist",
             "site_url": "https://docs.microbiomedata.org/runtime/",
             "theme": {"favicon": "assets/images/favicon.ico"}

--- a/content/home/src/conf.py
+++ b/content/home/src/conf.py
@@ -19,8 +19,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'NMDC Documentation'
-copyright = '2024, The NMDC Team'
-author = 'The NMDC Team'
+copyright = '2024, National Microbiome Data Collaborative'
+author = 'National Microbiome Data Collaborative'
 
 # The full version, including alpha/beta/rc tags
 release = '0.1'

--- a/content/legacy_home/src/conf.py
+++ b/content/legacy_home/src/conf.py
@@ -19,8 +19,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'NMDC Documentation'
-copyright = '2024, The NMDC Team'
-author = 'The NMDC Team'
+copyright = '2024, National Microbiome Data Collaborative'
+author = 'National Microbiome Data Collaborative'
 
 # The full version, including alpha/beta/rc tags
 release = '0.1'

--- a/pullers/runtime_docs/Dockerfile
+++ b/pullers/runtime_docs/Dockerfile
@@ -41,10 +41,12 @@ COPY assets/images/favicon.ico  nmdc-runtime/docs/assets/images/favicon.ico
 # - https://www.mkdocs.org/user-guide/cli/
 # - https://www.mkdocs.org/user-guide/configuration/#configuration-inheritance
 # - https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#favicon
+# - https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/?h=copyright#copyright-notice
 #
 RUN cd nmdc-runtime && \
     echo '{\
         "INHERIT": "mkdocs.yml",\
+        "copyright": "&copy; Copyright 2024, National Microbiome Data Collaborative",\
         "site_dir": "/html",\
         "site_url": "http://localhost:8000/",\
         "theme": {"favicon": "assets/images/favicon.ico"}\


### PR DESCRIPTION
In this branch, I made it so all copyright messages on the site are:

> &copy; Copyright 2024, National Microbiome Data Collaborative

Note:
- Material for MkDocs shows it as is
- Sphinx shows it with a period at the end