### PR TITLE
Update all copyright messages to say 2025 instead of 2024

### DIFF
--- a/.github/workflows/fetch-and-compile-runtime-docs.yml
+++ b/.github/workflows/fetch-and-compile-runtime-docs.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo '{
             "INHERIT": "mkdocs.yml",
-            "copyright": "&copy; Copyright 2024, National Microbiome Data Collaborative",
+            "copyright": "&copy; Copyright 2025, National Microbiome Data Collaborative",
             "site_dir": "${{ github.workspace }}/_dist",
             "site_url": "https://docs.microbiomedata.org/runtime/",
             "theme": {"favicon": "assets/images/favicon.ico"},

--- a/content/home/src/conf.py
+++ b/content/home/src/conf.py
@@ -19,7 +19,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'NMDC Documentation'
-copyright = '2024, National Microbiome Data Collaborative'
+copyright = '2025, National Microbiome Data Collaborative'
 author = 'National Microbiome Data Collaborative'
 
 # The full version, including alpha/beta/rc tags

--- a/pullers/runtime_docs/Dockerfile
+++ b/pullers/runtime_docs/Dockerfile
@@ -46,7 +46,7 @@ COPY assets/images/favicon.ico  nmdc-runtime/docs/assets/images/favicon.ico
 RUN cd nmdc-runtime && \
     echo '{\
         "INHERIT": "mkdocs.yml",\
-        "copyright": "&copy; Copyright 2024, National Microbiome Data Collaborative",\
+        "copyright": "&copy; Copyright 2025, National Microbiome Data Collaborative",\
         "site_dir": "/html",\
         "site_url": "http://localhost:8000/",\
         "theme": {"favicon": "assets/images/favicon.ico"},\

--- a/pullers/workflow_docs/conf.py
+++ b/pullers/workflow_docs/conf.py
@@ -10,7 +10,7 @@ author = 'National Microbiome Data Collaborative'
 
 # A copyright statement.
 # Docs: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-copyright
-copyright = '2024, National Microbiome Data Collaborative'
+copyright = '2025, National Microbiome Data Collaborative'
 
 # The documented project's _simplified_ and _full_ version identifiers.
 # Note: This chained assignment keeps them identical to one another.


### PR DESCRIPTION
On this branch, I updated all the copyright statements on our website so they reference the year 2025 instead of 2024.