### PR TITLE
Update home site footer so it contains link to privacy policy

### DIFF
--- a/content/home/src/_templates/footer.html
+++ b/content/home/src/_templates/footer.html
@@ -1,0 +1,14 @@
+{% extends "!footer.html" %}
+
+{% block extrafooter %}
+    <a href="https://microbiomedata.org/privacy" target="_blank">Privacy policy</a>.
+    {{ super() }}
+{% endblock %}
+
+{#
+    Note: `{{ super() }}` renders the block's original content (i.e. the content defined in
+          https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/footer.html#L60).
+          As of the time of this writing, there is no content there; but that could change over time.
+
+    Reference: https://www.sphinx-doc.org/en/master/development/html_themes/templating.html
+#}


### PR DESCRIPTION
This is in an attempt to comply with Google's requirements for using Google Analytics.

Here's what the link looks like (spotlight effect added by the screenshot tool).

![image](https://github.com/user-attachments/assets/e6d22214-db6d-4816-ac8f-dbff6995e88b)