### PR TITLE
Add lipidomics workflow documentation to workflows section of website

### DIFF
--- a/pullers/workflow_docs/fetch_docs_sources.sh
+++ b/pullers/workflow_docs/fetch_docs_sources.sh
@@ -29,15 +29,19 @@ mkdir -p /tmp/book/src/chapters
 # Note: The source files for Chapter 1 (the end-to-end MetaG chapter) reside in this `docs` Git repository.
 #       They get incorporated into the file tree by something other than this shell script.
 #
-mv /tmp/clones/ReadbasedAnalysis/docs /tmp/book/src/chapters/2_Read_Based_Taxonomy
-mv /tmp/clones/ReadsQC/docs           /tmp/book/src/chapters/3_Metagenome_Reads_QC
-mv /tmp/clones/metaAssembly/docs      /tmp/book/src/chapters/4_Metagenome_Assembly
-mv /tmp/clones/mg_annotation/docs     /tmp/book/src/chapters/5_Metagenome_and_Metatranscriptome_Annotation
-mv /tmp/clones/metaMAGs/docs          /tmp/book/src/chapters/6_Metagenome_Assembled_Genome
-mv /tmp/clones/metaT/docs             /tmp/book/src/chapters/7_Metatranscriptome_Workflow_Overview
-mv /tmp/clones/metaT_ReadsQC/docs     /tmp/book/src/chapters/8_Metatranscriptome_Reads_QC
-mv /tmp/clones/metaT_Assembly/docs    /tmp/book/src/chapters/9_Metatranscriptome_Assembly
-mv /tmp/clones/metaT_ReadCounts/docs  /tmp/book/src/chapters/10_Metatranscriptome_Expression
-mv /tmp/clones/metaPro/docs           /tmp/book/src/chapters/11_Metaproteomics
-mv /tmp/clones/metaMS/docs            /tmp/book/src/chapters/12_Metabolomics
-mv /tmp/clones/enviroMS/docs          /tmp/book/src/chapters/13_Natural_Organic_Matter
+# Note: The source files for Chapters `12_Metabolomics` and `14_Lipidomics` reside in the same repository as one
+#       another. Here, we move them from their respective subdirectories within that repository's `docs` directory.
+#
+mv /tmp/clones/ReadbasedAnalysis/docs        /tmp/book/src/chapters/2_Read_Based_Taxonomy
+mv /tmp/clones/ReadsQC/docs                  /tmp/book/src/chapters/3_Metagenome_Reads_QC
+mv /tmp/clones/metaAssembly/docs             /tmp/book/src/chapters/4_Metagenome_Assembly
+mv /tmp/clones/mg_annotation/docs            /tmp/book/src/chapters/5_Metagenome_and_Metatranscriptome_Annotation
+mv /tmp/clones/metaMAGs/docs                 /tmp/book/src/chapters/6_Metagenome_Assembled_Genome
+mv /tmp/clones/metaT/docs                    /tmp/book/src/chapters/7_Metatranscriptome_Workflow_Overview
+mv /tmp/clones/metaT_ReadsQC/docs            /tmp/book/src/chapters/8_Metatranscriptome_Reads_QC
+mv /tmp/clones/metaT_Assembly/docs           /tmp/book/src/chapters/9_Metatranscriptome_Assembly
+mv /tmp/clones/metaT_ReadCounts/docs         /tmp/book/src/chapters/10_Metatranscriptome_Expression
+mv /tmp/clones/metaPro/docs                  /tmp/book/src/chapters/11_Metaproteomics
+mv /tmp/clones/metaMS/docs/gcms_metabolomics /tmp/book/src/chapters/12_Metabolomics
+mv /tmp/clones/enviroMS/docs                 /tmp/book/src/chapters/13_Natural_Organic_Matter
+mv /tmp/clones/metaMS/docs/lcms_lipidomics   /tmp/book/src/chapters/14_Lipidomics

--- a/pullers/workflow_docs/index.rst
+++ b/pullers/workflow_docs/index.rst
@@ -35,3 +35,4 @@ Welcome to the NMDC Workflow documentation!
    chapters/11_Metaproteomics/index.rst
    chapters/12_Metabolomics/index.rst
    chapters/13_Natural_Organic_Matter/index.rst
+   chapters/14_Lipidomics/index.rst


### PR DESCRIPTION
On this branch, I updated the puller script to extract the lipidomics documentation source files from the pulled files; and I updated the workflows section's table of contents to include a link to that documentation. This new lipidomics chapter is chapter 14.

```diff
+ mv /tmp/clones/metaMS/docs/lcms_lipidomics   /tmp/book/src/chapters/14_Lipidomics
```

```diff
   chapters/12_Metabolomics/index.rst
   chapters/13_Natural_Organic_Matter/index.rst
+  chapters/14_Lipidomics/index.rst
```

Also, since that documentation's source files live in the same repo as some other documentation's (i.e. chapter 12's) source files that were already being pulled, and those other files now live in a subdirectory instead of at the top level of that repo's `docs` directory, I updated the puller to get them from their new home.

```diff
- mv /tmp/clones/metaMS/docs                   /tmp/book/src/chapters/12_Metabolomics
+ mv /tmp/clones/metaMS/docs/gcms_metabolomics /tmp/book/src/chapters/12_Metabolomics
```