### PR TITLE
Remove banner from website in preparation for launch

### DIFF
--- a/content/home/src/_static/js/index.js
+++ b/content/home/src/_static/js/index.js
@@ -28,10 +28,6 @@
 
     // Register a callback function to run when the web page has fully loaded.
     window.addEventListener("load", (event) => {
-        displayBanner(`
-            <strong>This website is in early development.</strong>
-            You can access our production documentation
-            <a href="https://microbiomedata.org/documentation/" style="color: black; text-decoration: underline;">here</a>.
-        `);
+        // Note: This is where you might invoke the `displayBanner` function on special occasions.
     });
 })();

--- a/development.md
+++ b/development.md
@@ -61,6 +61,16 @@ docker compose build --no-cache runtime-docs
 docker compose up --detach      runtime-docs
 ```
 
+If you **only** make changes to the documentation source files that reside in _this_ repository
+(i.e. those in `pullers/runtime_docs`), then you can issue this sequence of commands instead,
+which will allow Docker to _avoid refetching_ the source files from the upstream repo:
+
+```shell
+docker compose down             runtime-docs
+docker compose build            runtime-docs
+docker compose up --detach      runtime-docs
+```
+
 #### Workflow docs
 
 Nothing will automatically happen in the development environment when someone

--- a/pullers/runtime_docs/mkdocs_overrides/main.html
+++ b/pullers/runtime_docs/mkdocs_overrides/main.html
@@ -6,10 +6,7 @@
 {% extends "base.html" %}
 
 {#
-  Note: The `announce` block appears at the top of each page of the site.
+  Note: The `announce` block appears at the top of each page of the site. You can populate that block here
+        (as in Git commit #808f97c7230edd59999c9da4d36a3c2b31edac75) in order to make the banner visible.
   Reference: https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/?h=header#announcement-bar
 #}
-{% block announce %}
-  <strong>This website is in early development.</strong>
-  You can access our production documentation <a href="https://microbiomedata.org/documentation/">here</a>.
-{% endblock %}

--- a/pullers/workflow_docs/_static/js/index.js
+++ b/pullers/workflow_docs/_static/js/index.js
@@ -28,10 +28,6 @@
 
     // Register a callback function to run when the web page has fully loaded.
     window.addEventListener("load", (event) => {
-        displayBanner(`
-            <strong>This website is in early development.</strong>
-            You can access our production documentation
-            <a href="https://microbiomedata.org/documentation/" style="color: black; text-decoration: underline;">here</a>.
-        `);
+        // Note: This is where you might invoke the `displayBanner` function on special occasions.
     });
 })();


### PR DESCRIPTION
On this branch, I removed the banners from the home, workflows, and Runtime sections of the website.

#### Before

_These are screenshots of the production website._

![image](https://github.com/user-attachments/assets/b225f6ee-cfc7-4f2d-a0d6-091c522ecb7a)

![image](https://github.com/user-attachments/assets/29df9a45-f0bf-4731-bad6-8e3f20ec0805)

![image](https://github.com/user-attachments/assets/6bc0c856-d059-4690-b26a-1fb542bfa4e8)

#### After

_These are screenshots of a local copy of the website, running the code on this branch._

![image](https://github.com/user-attachments/assets/378cf7c7-3206-4d42-9c41-1267573e67ce)

![image](https://github.com/user-attachments/assets/508e7f57-f4b3-4e92-8f3b-c32ce639d492)

![image](https://github.com/user-attachments/assets/18e417c1-7eee-45d1-8ca3-59b64498b342)
