### PR TITLE
Embed new, YouTube-hosted videos in place of old, `nmdc-edge.org`-hosted ones

### DIFF
--- a/content/home/src/tutorials/nav_data_portal.md
+++ b/content/home/src/tutorials/nav_data_portal.md
@@ -1,9 +1,9 @@
 # Navigating the Data Portal
 
-<div align="center">
-    <video src="https://nmdc-edge.org/docs/videos/NMDC_portal_tutorial.mp4" width="80%" height="80%" controls />
+<div style="text-align: center; margin-bottom: 2rem;">
+    <!-- Note: The following HTML snippet was copied from the "Share > Embed" popup on the video's YouTube page. -->
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/JV-8QWoL4aY?si=mjVu2BCrEDuDYUIu" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
-<br><br>
 
 >NMDC Data Portal Tutorial Practice 
 >

--- a/content/home/src/tutorials/run_workflows.md
+++ b/content/home/src/tutorials/run_workflows.md
@@ -2,12 +2,12 @@
 
 ## NMDC EDGE QuickStart
 
-<div align="center">
-    <video src="https://nmdc-edge.org/docs/videos/nmdc-edge.mp4" width="80%" height="80%" controls />
+<div style="text-align: center; margin-bottom: 2rem;">
+    <!-- Note: The following HTML snippet was copied from the "Share > Embed" popup on the video's YouTube page. -->
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Z5Oq7BXo43k?si=pEVuglBAlggXqUBX" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
-<br><br>
 
-> ### NMDC EDGE QuickStart Tutorial Practice
+>NMDC EDGE QuickStart Tutorial Practice
 >
 >Task 1:  Create an NMDC EDGE account with either your email address or your ORCiD account.
 >


### PR DESCRIPTION
On this branch, I replaced the two videos shown in the screenshots below, with newer videos that are hosted on YouTube.

<img src="https://github.com/user-attachments/assets/d056e444-6d51-4741-b021-5cf4f38b624f" width="500" />

<img src="https://github.com/user-attachments/assets/9d223f2f-7538-421d-a570-1247f2b85f06" width="500" />

CC: @jkelliher-github 