### PR TITLE
Upgrade and pin third-party actions using commit hashes

### DIFF
--- a/.github/workflows/assemble-website.yml
+++ b/.github/workflows/assemble-website.yml
@@ -39,9 +39,9 @@ jobs:
       contents: read
     steps:
       - name: Check out commit  # Docs: https://github.com/actions/checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download all artifacts
-        uses: actions/download-artifact@v4  # Docs: https://github.com/actions/download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { path: artifacts }
       # Note: We use the `-T` option of the `cp` command so that the source directory name does not
       #       get appended to the destination directory name. It's short for `--no-target-directory`.
@@ -59,7 +59,7 @@ jobs:
           cp content/robots.txt _build/html/robots.txt
           ls -R _build/html
       - name: Save the result for publishing to GitHub Pages  # Docs: https://github.com/actions/upload-pages-artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _build/html
           # Note: The artifact name is "github-pages" by default; so, this specification is redundant. We include it

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
       - name: Get website file tree
-        uses: actions/download-artifact@v4  # docs: https://github.com/actions/download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: github-pages
           path: _downloads
@@ -29,7 +29,7 @@ jobs:
         # This step will populate `steps.lychee.outputs.exit_code` with the exit code returned by lychee.
         # Reference: https://github.com/lycheeverse/lychee-action
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           # Specify a Lychee version so the Lychee CLI options are always interpreted the same way,
           # even if the Lychee developers introduce breaking changes in a new Lychee version.
@@ -71,7 +71,7 @@ jobs:
         # This step will only run if both (a) lychee returned a non-zero exit code and (b) we are on the `main` branch.
         # Reference: https://docs.github.com/en/actions/learn-github-actions/variables#using-the-env-context-to-access-environment-variable-values
         if: steps.lychee.outputs.exit_code != 0 && github.ref == 'refs/heads/main'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Website file tree contains broken links
           content-filepath: ./lychee/out.md

--- a/.github/workflows/compile-home-docs.yml
+++ b/.github/workflows/compile-home-docs.yml
@@ -23,9 +23,9 @@ jobs:
       contents: read
     steps:
       - name: Check out commit  # Docs: https://github.com/actions/checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python  # Docs: https://github.com/actions/setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with: { python-version: '3.12' }
       - name: Install Python dependencies
         run: pip install -r requirements.txt
@@ -48,7 +48,7 @@ jobs:
           }' | mkdocs build -f -
         # Upload the result as an "artifact" so it can then be downloaded and used by another job.
       - name: Save the HTML for publishing later  # Docs: https://github.com/actions/upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: home-docs-as-html
           # Note: Relative `path` values here are relative to the _workspace_, not to the current working directory.

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -38,7 +38,7 @@ jobs:
       # Reference: https://github.com/actions/deploy-pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:
           # Note: The artifact name is "github-pages" by default; so, this specification is redundant. We include it
           #       anyway, here, as a reminder for people that will be implementing workflows that consume the same

--- a/.github/workflows/fetch-and-compile-runtime-docs.yml
+++ b/.github/workflows/fetch-and-compile-runtime-docs.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
         # Docs: https://github.com/actions/checkout
       - name: Check out commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check out commit from `nmdc-runtime/main`
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Notes:
           # - `repository` format is: "{owner_name}/{repo_name}"
@@ -27,7 +27,7 @@ jobs:
           path: _clones/microbiomedata/nmdc-runtime  # where, locally, to create the clone
         # Docs: https://github.com/actions/setup-python
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with: { python-version: '3.12' }
       - name: Install dependencies of `nmdc-runtime` docs
         run: | 
@@ -71,7 +71,7 @@ jobs:
           }' | mkdocs build -f -
         # Upload the result as an "artifact" so it can then be downloaded and used by another job.
       - name: Save the HTML for publishing later  # Docs: https://github.com/actions/upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runtime-docs-as-html
           # Note: Relative `path` values here are relative to the _workspace_, not to the current working directory.

--- a/.github/workflows/fetch-and-compile-workflow-docs.yml
+++ b/.github/workflows/fetch-and-compile-workflow-docs.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
         # Docs: https://github.com/actions/checkout
       - name: Check out commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with: { python-version: '3.12' }
       - name: Install dependencies of workflow documentation
         run: |
@@ -45,7 +45,7 @@ jobs:
         run: sphinx-build --builder html /tmp/book/src ${{ github.workspace }}/_dist
         # Upload the result as an "artifact" so it can then be downloaded and used by another job.
       - name: Save the HTML for publishing later  # Docs: https://github.com/actions/upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workflow-docs-as-html
           # Note: Relative `path` values here are relative to the _workspace_, not to the current working directory.


### PR DESCRIPTION
These changes implement the recommend security hardening step of [pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) using commit hashes. They also do an upgrade to avoid using [deprecated Node 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

---

Implementation note: these changes were automatically generated with [pinact](https://github.com/suzuki-shunsuke/pinact):
```
pinact run --update --min-age 7
```